### PR TITLE
Schedulerの挙動を修正

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -82,7 +82,9 @@ func AggregateInstance(pis map[string]*types.ProblemInstance, zps []*types.ZoneP
 
 	for _, p := range *pes {
 		min := strings.Split(*p.MachineImageName, "-")
-		pn := min[len(min)-1]
+		// image-nao-abcde #naoが問題コード
+		// ["image", "nao", "abcde"] にsplitして問題コードを取得している
+		pn := min[1]
 		if _, ok := pis[pn]; !ok {
 			lg.Error("Scheduler: Aggregate. This problem name not exists. The value is " + pn)
 			continue


### PR DESCRIPTION
マシンイメージが `image-{問題コード}` になる前提で書かれていたので、  
`image-{問題コード}-1` 形式にも対応出来るように修正した